### PR TITLE
Migrate UIKit to SwiftUI

### DIFF
--- a/ScreenCut/ScreenCut/Action/ScreenCutApp.swift
+++ b/ScreenCut/ScreenCut/Action/ScreenCutApp.swift
@@ -25,34 +25,22 @@ struct ScreenCutApp: App {
     }
     
     var body: some Scene {
-//         直接使用MenuBar 替代掉主窗口
+        // 直接使用MenuBar 替代掉主窗口
         MenuBarExtra("", systemImage: "scissors"){
-            Button("截屏") {
-                ScreenCut.saveScreenFullImage()
-            }
-            .padding()
-            Button("选择截屏") {
-                NSCursor.crosshair.set()
-                ScreenshotWindow().makeKeyAndOrderFront(nil)
-            }
-            Divider()
-            Button("偏好设置") {
-                let aboutWindowController = PreferenceSettingsViewController()
-                aboutWindowController.showWindow(nil)
-            }
-            .padding()
-            Button("关于"){
-                let aboutWindowController = AboutWindowController()
-                aboutWindowController.showWindow(nil)
-            }
-            .padding()
-            Divider()
-            Button("退出") {
-                NSApplication.shared.terminate(nil)
-            }
-            .keyboardShortcut("Q", modifiers: [.command])
+            MenuBarContentView()
         }
-        
+
+        // SwiftUI 原生的设置窗口
+        Settings {
+            PreferenceSettingsView()
+                .frame(width: 560, height: 500)
+        }
+
+        // SwiftUI 原生的关于窗口
+        WindowGroup("关于", id: "about") {
+            AboutView()
+                .frame(width: 540, height: 200)
+        }
     }
 }
 
@@ -64,5 +52,46 @@ extension Scene {
         else {
             return self
         }
+    }
+}
+
+// 菜单栏内容，使用 SwiftUI 的 openSettings/openWindow 打开设置与关于窗口
+private struct MenuBarContentView: View {
+    @Environment(\.openWindow) private var openWindow
+    @Environment(\.openSettings) private var openSettings
+
+    var body: some View {
+        Button("截屏") {
+            ScreenCut.saveScreenFullImage()
+        }
+        .padding()
+        Button("选择截屏") {
+            NSCursor.crosshair.set()
+            ScreenshotWindow().makeKeyAndOrderFront(nil)
+        }
+        Divider()
+        Button("偏好设置") {
+            if #available(macOS 13.0, *) {
+                openSettings()
+            } else {
+                let controller = PreferenceSettingsViewController()
+                controller.showWindow(nil)
+            }
+        }
+        .padding()
+        Button("关于"){
+            if #available(macOS 13.0, *) {
+                openWindow(id: "about")
+            } else {
+                let controller = AboutWindowController()
+                controller.showWindow(nil)
+            }
+        }
+        .padding()
+        Divider()
+        Button("退出") {
+            NSApplication.shared.terminate(nil)
+        }
+        .keyboardShortcut("Q", modifiers: [.command])
     }
 }


### PR DESCRIPTION
Migrate About and Preferences windows from AppKit NSWindowControllers to native SwiftUI Scenes.

The original request was to migrate UIKit to SwiftUI. Upon inspection, the app is a macOS application using AppKit and SwiftUI. This PR modernizes the About and Preferences windows by replacing their AppKit `NSWindowController` implementations with pure SwiftUI `Settings` and `WindowGroup` scenes, while ensuring backward compatibility for older macOS versions. Core AppKit-dependent features like the screenshot overlay remain unchanged to avoid breaking existing functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d086c54-8557-40d5-8ac8-be05bf74c652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d086c54-8557-40d5-8ac8-be05bf74c652">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

